### PR TITLE
Update prefix list

### DIFF
--- a/civo-geofeed.csv
+++ b/civo-geofeed.csv
@@ -7,3 +7,6 @@
 212.2.240.0/21,US,US-NJ,Secaucus,
 45.157.3.0/24,GB,GB-ENG,Exmouth,
 185.136.232.0/22,GB,GB-ENG,Swindon,
+2a10:c882::/32,DE,DE-HE,Frankfurt,
+2a10:c881::/32,GB,GB-ENG,London,
+2a10:c880::/32,US,US-NJ,Secaucus,

--- a/civo-geofeed.csv
+++ b/civo-geofeed.csv
@@ -1,8 +1,8 @@
-#prefix,country_code,region_code,city,postal
-45.157.0.0/24,US,US-NJ,Secaucus,07094
-45.157.1.0/24,GB,GB-ENG,London,CM17
-45.157.2.0/24,DE,DE-HE,Frankfurt,60487
-74.220.16.0/21,GB,GB-ENG,London,CM17
-74.220.24.0/21,DE,DE-HE,Frankfurt,60487
-212.2.240.0/21,US,US-NJ,Secaucus,07094
-45.157.3.0/24,GB,GB-ENG,Exmouth,EX8
+# IP Prefix,Country Code,Region Code,City,Postal Code
+45.157.0.0/24,US,US-NJ,Secaucus,
+45.157.1.0/24,GB,GB-ENG,London,
+45.157.2.0/24,DE,DE-HE,Frankfurt,
+74.220.16.0/21,GB,GB-ENG,London,
+74.220.24.0/21,DE,DE-HE,Frankfurt,
+212.2.240.0/21,US,US-NJ,Secaucus,
+45.157.3.0/24,GB,GB-ENG,Exmouth,

--- a/civo-geofeed.csv
+++ b/civo-geofeed.csv
@@ -6,3 +6,4 @@
 74.220.24.0/21,DE,DE-HE,Frankfurt,
 212.2.240.0/21,US,US-NJ,Secaucus,
 45.157.3.0/24,GB,GB-ENG,Exmouth,
+185.136.232.0/22,GB,GB-ENG,Swindon,


### PR DESCRIPTION
Per #3:
- Remove post code (deprecated field)
- Add `lon2` (?) range
- Add IPv6 ranges for `lon1`, `fra1` & `nyc1`
- Update header comment (used for rendering on Github, ignored by parsers)

Does not include ranges for `phx1`.